### PR TITLE
Fix docs site url

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -9,7 +9,7 @@ const config = {
   title: "Hutch",
   tagline: "Dinosaurs are cool",
   url: "https://health-informatics-uon.github.io",
-  baseUrl: "/hutch/",
+  baseUrl: "/hutch-trefx/",
   trailingSlash: false,
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "throw",
@@ -18,7 +18,7 @@ const config = {
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: "health-informatics-uon", // Usually your GitHub org/user name.
-  projectName: "hutch", // Usually your repo name.
+  projectName: "hutch-trefx", // Usually your repo name.
   deploymentBranch: "gh-pages",
 
   // Even if you don't use internalization, you can use this field to set useful
@@ -38,7 +38,7 @@ const config = {
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl: "https://github.com/health-informatics-uon/hutch/tree/main/website/",
+          editUrl: "https://github.com/health-informatics-uon/hutch-trefx/tree/main/website/",
         },
         blog: false,
         theme: {
@@ -71,7 +71,7 @@ const config = {
             label: "User Guide",
           },
           {
-            href: "https://github.com/health-informatics-uon/hutch",
+            href: "https://github.com/health-informatics-uon/hutch-trefx",
             position: "right",
             className: "header-github-link",
             "aria-label": "GitHub repository",
@@ -90,7 +90,7 @@ const config = {
               },
               {
                 label: "Hutch GitHub",
-                href: "https://github.com/health-informatics-uon/hutch",
+                href: "https://github.com/health-informatics-uon/hutch-trefx",
               },
               {
                 label: "TRE-FX Project Website",


### PR DESCRIPTION
<!--
INSTRUCTIONS:

1. Please complete all sections detailing an ACTION
2. All tasks must be checked off before merging
-->

<!--
  PR Guidance:
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

<!-- 
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->


## Pull Request Contents

<!--
ACTION: Delete any content types that don't apply to your pull request
-->

| |
|-|
🦋 Bug Fix

## Description

Fixes the `base-url` on the existing Hutch docs site.

<!--
ACTION: Summarise your Pull Request
-->

## Related Issues or other material

- [ ] This PR relates to one or more issues, detailed below

<!--
ACTION: Detail any issues this PR relates to, and then check the box.

NOTE: PRs without issues will not be merged.
-->

<!--
We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.

Be careful not to close parent tracking issues that this PR only completes PART of.
-->

## Screenshots, example outputs/behaviour etc.

<!--
ACTION: Add material or delete this section if it's not applicable
-->

## ✅ Added/updated tests?

- [ ] This PR contains relevant tests
  - Or doesn't need to per the below explanation

No tests relevant

<!--
ACTION: If tests have not been added or updated, explain why here
-->

- [x] I've completed all **actions** and **tasks** detailed in the PR Template
